### PR TITLE
Feature/output directory

### DIFF
--- a/src/transformers/executionFunctionAsync.js
+++ b/src/transformers/executionFunctionAsync.js
@@ -150,7 +150,6 @@ function isAsyncTest (context) {
 
 function isModuleHook (context) {
     var moduleHookKeys = ["setup", "teardown", "beforeEach", "afterEach"];
-    debugger;
 
     return context.key === "value" &&
         context.parent.node &&


### PR DESCRIPTION
Added ability to set output directory for files.
#### Example:

```
"d:\data\Cobalt ADC\Development\StaticContent\site\tests\dashboard\js\components\"  --outputDirectory="../testDirectory"
```

As a result **testDirectory** will be created and all files and folders from **components** directory will be in it.
